### PR TITLE
Add bigint to PostgresType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type PostgresType =
     | 'timestamptz'
     | 'text'
     | 'int'
+    | 'bigint'
     | 'float'
     | 'jsonb'
     | 'boolean'


### PR DESCRIPTION
We want to be able to select from `bigint` columns, so the type needs to be added to the `PostgresType` type (i.e. so that an `Entity` can have a field that specifies a `type` of `bigint`).

Perhaps `inferDatabaseType` should also consider that a JavaScript `number` might be too big for a postgres `int`, but we don't need that for now (because we specify the database type explicitly).