### PR TITLE
Remove unused lodash dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,10 @@
             "license": "MIT",
             "dependencies": {
                 "@zaptic-external/pg-plus": "^1.0.2",
-                "lodash.memoize": "4.1.2",
-                "lodash.omit": "4.5.0",
-                "lodash.pick": "4.4.0",
                 "lodash.snakecase": "4.1.1"
             },
             "devDependencies": {
                 "@types/chai": "4.2.15",
-                "@types/lodash.memoize": "4.1.6",
-                "@types/lodash.omit": "4.5.6",
-                "@types/lodash.pick": "4.4.6",
                 "@types/lodash.snakecase": "4.1.6",
                 "@types/mocha": "8.2.2",
                 "@types/pg": "7.14.11",
@@ -41,33 +35,6 @@
             "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash/-/lodash-4.14.196.tgz",
             "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==",
             "dev": true
-        },
-        "node_modules/@types/lodash.memoize": {
-            "version": "4.1.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz",
-            "integrity": "sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.omit": {
-            "version": "4.5.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",
-            "integrity": "sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.pick": {
-            "version": "4.4.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.pick/-/lodash.pick-4.4.6.tgz",
-            "integrity": "sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
         },
         "node_modules/@types/lodash.snakecase": {
             "version": "4.1.6",
@@ -1466,33 +1433,6 @@
             "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash/-/lodash-4.14.196.tgz",
             "integrity": "sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==",
             "dev": true
-        },
-        "@types/lodash.memoize": {
-            "version": "4.1.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz",
-            "integrity": "sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==",
-            "dev": true,
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.omit": {
-            "version": "4.5.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",
-            "integrity": "sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==",
-            "dev": true,
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.pick": {
-            "version": "4.4.6",
-            "resolved": "https://npm-packages-zaptic-159856059318.d.codeartifact.eu-west-2.amazonaws.com/npm/npm-zaptic/@types/lodash.pick/-/lodash.pick-4.4.6.tgz",
-            "integrity": "sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==",
-            "dev": true,
-            "requires": {
-                "@types/lodash": "*"
-            }
         },
         "@types/lodash.snakecase": {
             "version": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -13,16 +13,10 @@
     },
     "dependencies": {
         "@zaptic-external/pg-plus": "^1.0.2",
-        "lodash.memoize": "4.1.2",
-        "lodash.omit": "4.5.0",
-        "lodash.pick": "4.4.0",
         "lodash.snakecase": "4.1.1"
     },
     "devDependencies": {
         "@types/chai": "4.2.15",
-        "@types/lodash.memoize": "4.1.6",
-        "@types/lodash.omit": "4.5.6",
-        "@types/lodash.pick": "4.4.6",
         "@types/lodash.snakecase": "4.1.6",
         "@types/mocha": "8.2.2",
         "@types/pg": "7.14.11",


### PR DESCRIPTION
There is currently a known security vulnerability in `lodash.pick`:
https://github.com/advisories/GHSA-p6mc-m468-83gw

On inspecting this library, although `lodash.pick` is specified as a dependency, it is not being called in the source. Nor are `lodash.omit` or `lodash.memoize`.  These dependencies have therefore been removed to avoid the security flag.