### PR TITLE
Handle empty array in where clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zaptic-external/zorm",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "ZORM - a typed postgres ORM without classes",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/zorm.test.ts
+++ b/src/zorm.test.ts
@@ -173,6 +173,15 @@ describe('zorm', function () {
         assert.deepEqual(result, [france])
     })
 
+    it('handles empty arrays in where clause', async function () {
+        await countryEntity.create(database, { name: 'UK', isDeleted: false, region: 'Europe' })
+        await countryEntity.create(database, { name: 'Chance', isDeleted: false, region: 'Asia' })
+
+        const result = await countryEntity.select().where({ region: [] }).execute(database)
+
+        assert.deepEqual(result, [])
+    })
+
     it('handles nulls in insert statements', async function () {
         await countryEntity.create(database, { name: 'UK', isDeleted: false, region: 'Europe' })
         await countryEntity.create(database, { name: 'Chance', isDeleted: false, region: 'Asia' })


### PR DESCRIPTION
I was not sure whether to use `FALSE` as the condition, or use the empty array without a cast. I decided on `FALSE`, as there is less risk of running into some type wierdness caused by having the empty array without the cast.

Closes #9 